### PR TITLE
User Dashboard: Connected User

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
 class UsersController < ApplicationController
-  def show; end
+  def show
+    render locals: {
+      facade: DashboardShowFacade.new(current_user)
+    }
+  end
 end

--- a/app/facades/dashboard_show_facade.rb
+++ b/app/facades/dashboard_show_facade.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class DashboardShowFacade
+  attr_reader :top_songs
+
+  def initialize(current_user)
+    @top_songs = current_user.top_songs(10)
+  end
+end

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -1,0 +1,2 @@
+class Song < ApplicationRecord
+end

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -1,2 +1,4 @@
 class Song < ApplicationRecord
+  has_many :user_songs
+  has_many :users, through: :user_songs
 end

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Song < ApplicationRecord
   has_many :user_songs
   has_many :users, through: :user_songs

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,12 @@
 class User < ApplicationRecord
   has_many :user_songs
   has_many :songs, through: :user_songs
+
+  def top_songs(limit)
+    songs
+      .joins(:user_songs)
+      .select("songs.*, user_songs.play_count, user_songs.power_ranking")
+      .order(power_ranking: :DESC)
+      .limit(limit)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,7 @@ class User < ApplicationRecord
   def top_songs(limit)
     songs
       .joins(:user_songs)
-      .select("songs.*, user_songs.play_count, user_songs.power_ranking")
+      .select('songs.*, user_songs.play_count, user_songs.power_ranking')
       .order(power_ranking: :DESC)
       .limit(limit)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
 
 class User < ApplicationRecord
+  has_many :user_songs
+  has_many :songs, through: :user_songs
 end

--- a/app/models/user_song.rb
+++ b/app/models/user_song.rb
@@ -1,0 +1,4 @@
+class UserSong < ApplicationRecord
+  belongs_to :user
+  belongs_to :song
+end

--- a/app/models/user_song.rb
+++ b/app/models/user_song.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class UserSong < ApplicationRecord
   belongs_to :user
   belongs_to :song

--- a/app/services/strava_service.rb
+++ b/app/services/strava_service.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+# frozen_8string_literal: true
 
 class StravaService
   def initialize(user_token)

--- a/app/services/strava_service.rb
+++ b/app/services/strava_service.rb
@@ -1,4 +1,4 @@
-# frozen_8string_literal: true
+# frozen_string_literal: true
 
 class StravaService
   def initialize(user_token)

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,1 +1,13 @@
 <h1> <%= current_user.strava_firstname %> </h1>
+
+<section class="top-songs">
+  <div class="song">
+    <ul>
+      <li class="song-rank"></li>
+      <li class="song-title"><a href="#"></a></li>
+      <li class="song-play-count"></li>
+      <li class="song-last-played"></li>
+      <li class="song-power-index"></li>
+    </ul>
+  </div>
+</section>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,13 +1,15 @@
 <h1> <%= current_user.strava_firstname %> </h1>
 
 <section class="top-songs">
-  <div class="song">
-    <ul>
-      <li class="song-rank"></li>
-      <li class="song-title"><a href="#"></a></li>
-      <li class="song-play-count"></li>
-      <li class="song-last-played"></li>
-      <li class="song-power-index"></li>
-    </ul>
-  </div>
+  <% facade.top_songs.each do |song| %>
+    <div class="song">
+      <ul>
+        <li class="song-power-index"><%= song.power_ranking %></li>
+        <li class="song-title"><a href="<%= song_path(song.id) %>"><%= song.title %></a></li>
+        <li class="song-artist"><%= song.artist %></li>
+        <li class="song-play-count"><%= song.play_count %></li>
+        <li class="song-last-played"><%= song.updated_at %></li>
+      </ul>
+    </div>
+  <% end %>
 </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   root 'welcome#index'
 
   get '/dashboard', to: 'users#show'
+  resources :songs, only: [:show]
 
   get 'auth/strava/callback', to: 'login#create'
 end

--- a/db/migrate/20190719030929_create_songs.rb
+++ b/db/migrate/20190719030929_create_songs.rb
@@ -1,0 +1,15 @@
+class CreateSongs < ActiveRecord::Migration[5.2]
+  def change
+    create_table :songs do |t|
+      t.string :spotify_id
+      t.string :title
+      t.string :artist
+      t.string :album
+      t.string :spotify_url
+      t.string :album_art_url
+      t.integer :length
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190719031422_create_user_songs.rb
+++ b/db/migrate/20190719031422_create_user_songs.rb
@@ -1,0 +1,12 @@
+class CreateUserSongs < ActiveRecord::Migration[5.2]
+  def change
+    create_table :user_songs do |t|
+      t.references :user, foreign_key: true
+      t.references :song, foreign_key: true
+      t.integer :play_count
+      t.float :power_ranking
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_19_030929) do
+ActiveRecord::Schema.define(version: 2019_07_19_031422) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,6 +27,17 @@ ActiveRecord::Schema.define(version: 2019_07_19_030929) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "user_songs", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "song_id"
+    t.integer "play_count"
+    t.float "power_ranking"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["song_id"], name: "index_user_songs_on_song_id"
+    t.index ["user_id"], name: "index_user_songs_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.integer "strava_uid"
     t.string "strava_firstname"
@@ -36,4 +47,6 @@ ActiveRecord::Schema.define(version: 2019_07_19_030929) do
     t.string "spotify_token"
   end
 
+  add_foreign_key "user_songs", "songs"
+  add_foreign_key "user_songs", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_18_003840) do
+ActiveRecord::Schema.define(version: 2019_07_19_030929) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "songs", force: :cascade do |t|
+    t.string "spotify_id"
+    t.string "title"
+    t.string "artist"
+    t.string "album"
+    t.string "spotify_url"
+    t.string "album_art_url"
+    t.integer "length"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.integer "strava_uid"

--- a/spec/factories/songs.rb
+++ b/spec/factories/songs.rb
@@ -1,11 +1,11 @@
 FactoryBot.define do
   factory :song do
-    spotify_id { "MyString" }
-    title { "MyString" }
-    artist { "MyString" }
-    album { "MyString" }
-    spotify_url { "MyString" }
-    album_art_url { "MyString" }
+    spotify_id { 'MyString' }
+    title { 'MyString' }
+    artist { 'MyString' }
+    album { 'MyString' }
+    spotify_url { 'MyString' }
+    album_art_url { 'MyString' }
     length { 1 }
   end
 end

--- a/spec/factories/songs.rb
+++ b/spec/factories/songs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :song do
     spotify_id { 'MyString' }

--- a/spec/factories/songs.rb
+++ b/spec/factories/songs.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :song do
+    spotify_id { "MyString" }
+    title { "MyString" }
+    artist { "MyString" }
+    album { "MyString" }
+    spotify_url { "MyString" }
+    album_art_url { "MyString" }
+    length { 1 }
+  end
+end

--- a/spec/factories/user_songs.rb
+++ b/spec/factories/user_songs.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :user_song do
+    user { nil }
+    song { nil }
+    play_count { 1 }
+    power_ranking { 1.5 }
+  end
+end

--- a/spec/factories/user_songs.rb
+++ b/spec/factories/user_songs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :user_song do
     user { nil }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :user do
+    strava_uid { 1234 }
+    strava_firstname { "MyString" }
+    strava_lastname { "MyString" }
+    strava_token { "MyString" }
+    spotify_uid { "MyString" }
+    spotify_token { "MyString" }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :user do
     strava_uid { 1234 }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,10 +1,10 @@
 FactoryBot.define do
   factory :user do
     strava_uid { 1234 }
-    strava_firstname { "MyString" }
-    strava_lastname { "MyString" }
-    strava_token { "MyString" }
-    spotify_uid { "MyString" }
-    spotify_token { "MyString" }
+    strava_firstname { 'MyString' }
+    strava_lastname { 'MyString' }
+    strava_token { 'MyString' }
+    spotify_uid { 'MyString' }
+    spotify_token { 'MyString' }
   end
 end

--- a/spec/features/users/user_can_see_a_list_of_songs_on_dashboard_spec.rb
+++ b/spec/features/users/user_can_see_a_list_of_songs_on_dashboard_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe 'As a user who has connected their Spotify account' do
       expect(page).to have_content(@user.strava_firstname)
 
       within '.top-songs' do
+        expect(page).to have_selector('.song', count: 10)
         within first(".song") do
           expect(page).to have_css('.song-rank')
           expect(page).to have_css('.song-title a')

--- a/spec/features/users/user_can_see_a_list_of_songs_on_dashboard_spec.rb
+++ b/spec/features/users/user_can_see_a_list_of_songs_on_dashboard_spec.rb
@@ -5,12 +5,18 @@ require 'rails_helper'
 RSpec.describe 'As a user who has connected their Spotify account' do
   describe 'when I visit the dashboard path' do
     before(:each) do
-      @user = User.create!(strava_uid: 123,
-                          strava_firstname: 'Homer',
-                          strava_lastname: 'Simpson',
-                          strava_token: '12345abcde',
-                          spotify_token: 'abcde12345',
-                          spotify_uid: 'string_token')
+      @user = create(:user)
+      create(:user_song, user: @user, song: create(:song))
+      create(:user_song, user: @user, song: create(:song))
+      create(:user_song, user: @user, song: create(:song))
+      create(:user_song, user: @user, song: create(:song))
+      create(:user_song, user: @user, song: create(:song))
+      create(:user_song, user: @user, song: create(:song))
+      create(:user_song, user: @user, song: create(:song))
+      create(:user_song, user: @user, song: create(:song))
+      create(:user_song, user: @user, song: create(:song))
+      create(:user_song, user: @user, song: create(:song))
+      create(:user_song, user: @user, song: create(:song))
 
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
     end
@@ -22,11 +28,11 @@ RSpec.describe 'As a user who has connected their Spotify account' do
       within '.top-songs' do
         expect(page).to have_selector('.song', count: 10)
         within first(".song") do
-          expect(page).to have_css('.song-rank')
+          expect(page).to have_css('.song-power-index')
           expect(page).to have_css('.song-title a')
+          expect(page).to have_css('.song-artist')
           expect(page).to have_css('.song-play-count')
           expect(page).to have_css('.song-last-played')
-          expect(page).to have_css('.song-power-index')
         end
       end
     end

--- a/spec/features/users/user_can_see_a_list_of_songs_on_dashboard_spec.rb
+++ b/spec/features/users/user_can_see_a_list_of_songs_on_dashboard_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'As a user who has connected their Spotify account' do
+  describe 'when I visit the dashboard path' do
+    before(:each) do
+      @user = User.create!(strava_uid: 123,
+                          strava_firstname: 'Homer',
+                          strava_lastname: 'Simpson',
+                          strava_token: '12345abcde',
+                          spotify_token: 'abcde12345',
+                          spotify_uid: 'string_token')
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+    end
+    it "I see a list of 10 songs " do
+      visit dashboard_path
+      
+      expect(page).to have_content(@user.strava_firstname)
+
+      within '.top-songs' do
+        within first(".song") do
+          expect(page).to have_css('.song-rank')
+          expect(page).to have_css('.song-title a')
+          expect(page).to have_css('.song-play-count')
+          expect(page).to have_css('.song-last-played')
+          expect(page).to have_css('.song-power-index')
+        end
+      end
+    end
+  end
+end

--- a/spec/features/users/user_can_see_a_list_of_songs_on_dashboard_spec.rb
+++ b/spec/features/users/user_can_see_a_list_of_songs_on_dashboard_spec.rb
@@ -20,14 +20,14 @@ RSpec.describe 'As a user who has connected their Spotify account' do
 
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
     end
-    it "I see a list of 10 songs " do
+    it 'I see a list of 10 songs ' do
       visit dashboard_path
       
       expect(page).to have_content(@user.strava_firstname)
-
+      save_and_open_page
       within '.top-songs' do
         expect(page).to have_selector('.song', count: 10)
-        within first(".song") do
+        within first('.song') do
           expect(page).to have_css('.song-power-index')
           expect(page).to have_css('.song-title a')
           expect(page).to have_css('.song-artist')

--- a/spec/models/song_spec.rb
+++ b/spec/models/song_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Song, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/song_spec.rb
+++ b/spec/models/song_spec.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Song, type: :model do
-  it {should have_many(:users)}
+  it { should have_many(:users) }
 end

--- a/spec/models/song_spec.rb
+++ b/spec/models/song_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe Song, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it {should have_many(:users)}
 end

--- a/spec/models/user_song_spec.rb
+++ b/spec/models/user_song_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe UserSong, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/user_song_spec.rb
+++ b/spec/models/user_song_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe UserSong, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it { should belong_to(:user) }
+  it { should belong_to(:song) }
 end

--- a/spec/models/user_song_spec.rb
+++ b/spec/models/user_song_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe UserSong, type: :model do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  it {should have_many(:songs)}
+  it { should have_many(:songs) }
 
   it '.top_songs by limit' do
     user = create(:user)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,4 +2,29 @@ require 'rails_helper'
 
 RSpec.describe User, type: :model do
   it {should have_many(:songs)}
+
+  it '.top_songs by limit' do
+    user = create(:user)
+    song_1 = create(:song)
+    song_2 = create(:song)
+    song_3 = create(:song)
+    user_song_1 = create(:user_song, user: user, song: song_1, power_ranking: 7)
+    user_song_2 = create(:user_song, user: user, song: song_2)
+    user_song_3 = create(:user_song, user: user, song: song_3)
+
+    results = user.top_songs(1)
+    result = user.top_songs(1).first
+
+    expect(results.length).to eq(1)
+    expect(result.id).to eq(song_1.id)
+    expect(result.spotify_id).to eq(song_1.spotify_id)
+    expect(result.title).to eq(song_1.title)
+    expect(result.artist).to eq(song_1.artist)
+    expect(result.album).to eq(song_1.album)
+    expect(result.spotify_url).to eq(song_1.spotify_url)
+    expect(result.album_art_url).to eq(song_1.album_art_url)
+    expect(result.length).to eq(song_1.length)
+    expect(result.play_count).to eq(user_song_1.play_count)
+    expect(result.power_ranking).to eq(user_song_1.power_ranking)
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  it {should have_many(:songs)}
+end


### PR DESCRIPTION
As a user who has connected their Spotify, when I visit my dashboard:

I see my top 10 songs with the rank, song title, artist, play count, last played, and 'power index'
I see the song title as a link to the song show page

adds users dashboard facade
adds song model and test
adds user_song model and test
adds user model test
adds users dashboard logic to iterate over songs
adds song show route
adds user, song, user_song factory
adds method of top_songs for user and test

resolves #5 