### PR TITLE
Hound Config

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,2 @@
+rubocop:
+  config_file: .rubocop.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,19 @@
+AllCops:
+  Exclude:
+    - 'db/**/*.rb'
+    - 'db/schema.rb'
+    - 'db/seeds.rb'
+    - 'node_modules/**/*'
+    - 'bin/*'
+
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*_spec.rb'
+    - 'config/routes.rb'
+    - 'config/environments/development.rb'
+    - 'lib/tasks/*.rake'
+
+Metrics/LineLength:
+  Exclude:
+    - 'spec/**/*_spec.rb'
+    - 'lib/tasks/*.rake'


### PR DESCRIPTION
Quick PR to address the Hound configuration used in Github. This configuration should hopefully allow us to pay attention to the important style rules for Ruby, instead of being bombarded with comments on Spec files.