### PR TITLE
Spotify Playlist Export

### DIFF
--- a/app/controllers/playlist_controller.rb
+++ b/app/controllers/playlist_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class PlaylistController < ApplicationController
+  def create
+    playlist = add_playlist(current_user.spotify_uid, params[:playlist_name])
+    spotify_service.add_songs_to_playlist(playlist[:id], params[:song_uris])
+    flash[:success] = 'Playlist successfully added!'
+    redirect_to dashboard_path
+  end
+
+  private
+
+  def add_playlist(spotify_user_id, playlist_name)
+    spotify_service.create_user_playlist(spotify_user_id, playlist_name)
+  end
+
+  def spotify_service
+    @spotify_service ||= SpotifyService.new(current_user.spotify_token)
+  end
+end

--- a/app/controllers/spotify_controller.rb
+++ b/app/controllers/spotify_controller.rb
@@ -10,9 +10,9 @@ class SpotifyController < ApplicationController
     redirect_to root_path
   end
 
-	def index
-		songs_data = SpotifyService.new(current_user.spotify_token).get_user_songs[:items]
-		SongSifter.new(songs_data, current_user).sift_songs
-		redirect_to dashboard_path
-	end
+  def index
+    songs_data = SpotifyService.new(current_user.spotify_token).get_user_songs[:items]
+    SongSifter.new(songs_data, current_user).sift_songs
+    redirect_to dashboard_path
+  end
 end

--- a/app/controllers/spotify_controller.rb
+++ b/app/controllers/spotify_controller.rb
@@ -5,12 +5,13 @@ class SpotifyController < ApplicationController
   def create
     token_info = SpotifyOauthGenerator.new(params['code']).connect_to_spotify
     current_user.spotify_token = token_info['access_token']
+    current_user.spotify_uid = params[:id]
     current_user.save
     redirect_to root_path
   end
 
 	def index
-		songs_data = SpotifyService.new(current_user.spotify_token).get_user_songs[:items] 
+		songs_data = SpotifyService.new(current_user.spotify_token).get_user_songs[:items]
 		SongSifter.new(songs_data, current_user).sift_songs
 		redirect_to dashboard_path
 	end

--- a/app/facades/dashboard_show_facade.rb
+++ b/app/facades/dashboard_show_facade.rb
@@ -9,9 +9,13 @@ class DashboardShowFacade
     @user = current_user
   end
 
+  def spotify_song_uris
+    recommended_songs.map { |song| 'spotify:track:' + song[:spotify_id] }.join(',')
+  end
+
   def recommended_songs
-    songs = @user.top_songs(5).map{|song| song.spotify_id}.join(',')
-    RecommendedService.new.get_recommendations(songs)
+    songs = @user.top_songs(5).map{ |song| song.spotify_id }.join(',')
+    @recommended_songs ||= recommended_service.get_recommendations(songs)
   end
 
   def build_link
@@ -25,5 +29,11 @@ class DashboardShowFacade
 
   def user_name
     @user.strava_firstname + ' ' + @user.strava_lastname
+  end
+
+  private
+
+  def recommended_service
+    @recommended_service ||= RecommendedService.new
   end
 end

--- a/app/facades/dashboard_show_facade.rb
+++ b/app/facades/dashboard_show_facade.rb
@@ -14,7 +14,7 @@ class DashboardShowFacade
   end
 
   def recommended_songs
-    songs = @user.top_songs(5).map{ |song| song.spotify_id }.join(',')
+    songs = @user.top_songs(5).map(&:spotify_id).join(',')
     @recommended_songs ||= recommended_service.get_recommendations(songs)
   end
 

--- a/app/services/spotify_service.rb
+++ b/app/services/spotify_service.rb
@@ -12,7 +12,29 @@ class SpotifyService
     get_json(url, params)
   end
 
+  def create_user_playlist(spotify_user_id, playlist_name)
+    post_playlist("/v1/users/#{spotify_user_id}/playlists", "{\"name\":\"#{playlist_name}\", \"public\":true}")
+  end
+
+  def add_songs_to_playlist(playlist_id, song_uris)
+    post_songs("/v1/playlists/#{playlist_id}/tracks?uris=#{song_uris}")
+  end
+
   private
+
+  def post_songs(url)
+    response = conn.post(url)
+    JSON.parse(response.body, symbolize_names: true)
+  end
+
+  def post_playlist(url, params = {})
+    response = conn.post do |req|
+      req.url url
+      req.headers['Content-Type'] = 'application/json'
+      req.body = params
+    end
+    JSON.parse(response.body, symbolize_names: true)
+  end
 
   def get_json(url, params = {})
     response = conn.get(url, params)

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,5 +1,4 @@
 <section class="row">
-  <%# <div class="col-md-2"></div> %>
   <div class="col-lg-12">
     <section class="py-md-3">
       <h1> <%= facade.user_name %>, Welcome to FastTracks </h1>
@@ -48,15 +47,20 @@
         <% if facade.top_songs.length > 4 %>
           <section class="recommended-songs">
             <h4>Recommended Songs</h4>
-            <% facade.recommended_songs.each do |song| %>
-              <div class="song">
-                <iframe src="https://open.spotify.com/embed/track/<%= song[:spotify_id] %>" width="300" height="80" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe>
-              </div>
-            <% end %>
+              <section class='playlist-export'>
+                <%= form_tag playlist_path(song_uris: facade.spotify_song_uris), remote: true, method: :post do %>
+                  <%= text_field_tag :playlist_name %>
+                  <%= submit_tag 'Create Playlist', class: 'btn btn-success' %>
+                <% end %>
+              </section>
+              <% facade.recommended_songs.each do |song| %>
+                <div class="song">
+                  <iframe src="https://open.spotify.com/embed/track/<%= song[:spotify_id] %>" width="300" height="80" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe>
+                </div>
+              <% end %>
           </section>
         <% end %>
       </section>
     </div>
   </div>
-  <%# <div class="col-md-2"></div> %>
 </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,5 @@ Rails.application.routes.draw do
   get 'auth/strava/callback', to: 'login#create'
   get 'auth/spotify/callback', to: 'spotify#create'
   get 'spotify/songs', to: 'spotify#index'
-  
   post '/playlist', to: 'playlist#create'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,4 +10,6 @@ Rails.application.routes.draw do
   get 'auth/strava/callback', to: 'login#create'
   get 'auth/spotify/callback', to: 'spotify#create'
   get 'spotify/songs', to: 'spotify#index'
+  
+  post '/playlist', to: 'playlist#create'
 end

--- a/spec/cassettes/export_spotify_playlist.yml
+++ b/spec/cassettes/export_spotify_playlist.yml
@@ -1,0 +1,189 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.spotify.com/v1/users/<SPOTIFY_UID>/playlists
+    body:
+      encoding: UTF-8
+      string: '{"name":"New Jams", "public":true}'
+    headers:
+      Authorization:
+      - Bearer <SPOTIFY_TEST_TOKEN>
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Cache-Control:
+      - private, max-age=0
+      Location:
+      - https://api.spotify.com/v1/playlists/1XEXC0y3Jl6lwViv1g7eZr
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Accept, Authorization, Origin, Content-Type, Retry-After
+      Access-Control-Allow-Methods:
+      - GET, POST, OPTIONS, PUT, DELETE, PATCH
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Max-Age:
+      - '604800'
+      Date:
+      - Tue, 23 Jul 2019 01:35:22 GMT
+      Via:
+      - 1.1 google
+      Alt-Svc:
+      - clear
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "collaborative" : false,
+          "description" : null,
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/playlist/1XEXC0y3Jl6lwViv1g7eZr"
+          },
+          "followers" : {
+            "href" : null,
+            "total" : 0
+          },
+          "href" : "https://api.spotify.com/v1/playlists/1XEXC0y3Jl6lwViv1g7eZr",
+          "id" : "1XEXC0y3Jl6lwViv1g7eZr",
+          "images" : [ ],
+          "name" : "New Jams",
+          "owner" : {
+            "display_name" : "<SPOTIFY_UID>",
+            "external_urls" : {
+              "spotify" : "https://open.spotify.com/user/<SPOTIFY_UID>"
+            },
+            "href" : "https://api.spotify.com/v1/users/<SPOTIFY_UID>",
+            "id" : "<SPOTIFY_UID>",
+            "type" : "user",
+            "uri" : "spotify:user:<SPOTIFY_UID>"
+          },
+          "primary_color" : null,
+          "public" : true,
+          "snapshot_id" : "MSw5YzExYTgwYWZiZTZkYjA5MDkwODA3MmIxZDI4NjUwNDE3YTU2YTQ4",
+          "tracks" : {
+            "href" : "https://api.spotify.com/v1/playlists/1XEXC0y3Jl6lwViv1g7eZr/tracks",
+            "items" : [ ],
+            "limit" : 100,
+            "next" : null,
+            "offset" : 0,
+            "previous" : null,
+            "total" : 0
+          },
+          "type" : "playlist",
+          "uri" : "spotify:playlist:1XEXC0y3Jl6lwViv1g7eZr"
+        }
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 01:35:20 GMT
+- request:
+    method: post
+    uri: https://api.spotify.com/v1/playlists/1XEXC0y3Jl6lwViv1g7eZr/tracks?uris=spotify:track:0l9jBZWCFyKdYVVYrzzTMR,spotify:track:1PCkbjg2mFmrGAqdP8LB8F,spotify:track:4eyHT04G33u8OmB49w8dYj,spotify:track:5bBsxYuiDd8LUb3kF6RoYL,spotify:track:7gRVrDCQcoEnHrPxdblf6I
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <SPOTIFY_TEST_TOKEN>
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Length:
+      - '0'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Cache-Control:
+      - private, max-age=0
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Accept, Authorization, Origin, Content-Type, Retry-After
+      Access-Control-Allow-Methods:
+      - GET, POST, OPTIONS, PUT, DELETE, PATCH
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Max-Age:
+      - '604800'
+      Date:
+      - Tue, 23 Jul 2019 01:35:22 GMT
+      Via:
+      - 1.1 google
+      Alt-Svc:
+      - clear
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "snapshot_id" : "MixjMTZjNWE2YjQ4MjdlZjJjMDQwOTVhYmVjMjg2YTg1OTY3MTVlN2Zk"
+        }
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 01:35:20 GMT
+- request:
+    method: get
+    uri: https://fast-tracks-flask.herokuapp.com/api/v1/recommended?limit=5&song_ids=2MIcpZ7MBeCUEVFDBqU7Ei,4v6dF5830rtgjYr0uov248,2SpLqYLZ5GQTFTDwA4xwGS,5fUZNS9QZXOg0aYjnIjr1H,0tuE3l1TPJ9tKG4w63kgtf
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Server:
+      - gunicorn/19.9.0
+      Date:
+      - Tue, 23 Jul 2019 01:35:23 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1382'
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '[{"album":"No Matter What","album_art_url":"https://i.scdn.co/image/9f7581c669e17612894f6b6656799cde7bb07cea","artist":"BoA","length":185990,"spotify_id":"0Yc2gPL8g9P6FUEFXhtI3q","spotify_url":"https://open.spotify.com/track/0Yc2gPL8g9P6FUEFXhtI3q","title":"No
+        Matter What"},{"album":"Hell Can Wait","album_art_url":"https://i.scdn.co/image/a20341bb51c43dd58a426e4078f0898cd4f46be7","artist":"Vince
+        Staples","length":247013,"spotify_id":"7nUsDCJPnJTqNUqxipnNy4","spotify_url":"https://open.spotify.com/track/7nUsDCJPnJTqNUqxipnNy4","title":"Screen
+        Door"},{"album":"Kero & Azure","album_art_url":"https://i.scdn.co/image/ca1834e3baeb078d98ba2f35931b26d54b013b76","artist":"Kero
+        One","length":186390,"spotify_id":"7oCl9OYECGEdwGQ8mFnaCB","spotify_url":"https://open.spotify.com/track/7oCl9OYECGEdwGQ8mFnaCB","title":"Let
+        Me Show You"},{"album":"One Step","album_art_url":"https://i.scdn.co/image/9d54842cc7ed33ffb03c0893897ed34a00f72493","artist":"Hyolyn","length":196802,"spotify_id":"5V3cwxCMYUHCf8dtWgbw7e","spotify_url":"https://open.spotify.com/track/5V3cwxCMYUHCf8dtWgbw7e","title":"One
+        Step (feat.Jay Park)"},{"album":"Hump Days","album_art_url":"https://i.scdn.co/image/1a4bb5b379ac2bf944aebfb32a4c8d854e453d06","artist":"Lil
+        Dicky","length":240876,"spotify_id":"0zRap4IN4GliABWHrElGWL","spotify_url":"https://open.spotify.com/track/0zRap4IN4GliABWHrElGWL","title":"Flames"}]
+
+'
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 01:35:21 GMT
+recorded_with: VCR 5.0.0

--- a/spec/features/users/user_can_export_recommended_songs_to_spotify_spec.rb
+++ b/spec/features/users/user_can_export_recommended_songs_to_spotify_spec.rb
@@ -30,8 +30,18 @@ RSpec.describe 'As a registered user' do
       within '.recommended-songs' do
         within '.playlist-export' do
           expect(page).to have_field :playlist_name
-          expect(page).to have_button 'Create Spotify Playlist'
+          expect(page).to have_button 'Create Playlist'
         end
+      end
+    end
+
+    describe 'and fill out the form to export a playlist to Spotify correctly' do
+      it 'I stay on my current path and see a message telling me the playlist was added' do
+        fill_in :playlist_name, with: 'New Jams'
+        click_button 'Create Playlist'
+
+        expect(current_path).to eq(dashboard_path)
+        expect(page).to have_content('Playlist successfully added!')
       end
     end
   end

--- a/spec/features/users/user_can_export_recommended_songs_to_spotify_spec.rb
+++ b/spec/features/users/user_can_export_recommended_songs_to_spotify_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'As a registered user' do
   describe 'when I visit my dashboard' do
     before :each do
-      @user = create(:user)
+      @user = create(:user, spotify_uid: ENV['SPOTIFY_UID'], spotify_token: ENV['SPOTIFY_TEST_TOKEN'])
 
       create(:user_song, user: @user, power_ranking: 0.9, song: create(:song, spotify_id: '2MIcpZ7MBeCUEVFDBqU7Ei'))
       create(:user_song, user: @user, power_ranking: 0.8, song: create(:song, spotify_id: '4v6dF5830rtgjYr0uov248'))
@@ -38,7 +38,10 @@ RSpec.describe 'As a registered user' do
     describe 'and fill out the form to export a playlist to Spotify correctly' do
       it 'I stay on my current path and see a message telling me the playlist was added' do
         fill_in :playlist_name, with: 'New Jams'
-        click_button 'Create Playlist'
+
+        VCR.use_cassette 'export_spotify_playlist' do
+          click_button 'Create Playlist'
+        end
 
         expect(current_path).to eq(dashboard_path)
         expect(page).to have_content('Playlist successfully added!')

--- a/spec/features/users/user_can_export_recommended_songs_to_spotify_spec.rb
+++ b/spec/features/users/user_can_export_recommended_songs_to_spotify_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'As a registered user' do
+  describe 'when I visit my dashboard' do
+    before :each do
+      @user = create(:user)
+
+      create(:user_song, user: @user, power_ranking: 0.9, song: create(:song, spotify_id: '2MIcpZ7MBeCUEVFDBqU7Ei'))
+      create(:user_song, user: @user, power_ranking: 0.8, song: create(:song, spotify_id: '4v6dF5830rtgjYr0uov248'))
+      create(:user_song, user: @user, power_ranking: 0.7, song: create(:song, spotify_id: '2SpLqYLZ5GQTFTDwA4xwGS'))
+      create(:user_song, user: @user, power_ranking: 0.6, song: create(:song, spotify_id: '5fUZNS9QZXOg0aYjnIjr1H'))
+      create(:user_song, user: @user, power_ranking: 0.5, song: create(:song, spotify_id: '0tuE3l1TPJ9tKG4w63kgtf'))
+      create(:user_song, user: @user, song: create(:song))
+      create(:user_song, user: @user, song: create(:song))
+      create(:user_song, user: @user, song: create(:song))
+      create(:user_song, user: @user, song: create(:song))
+      create(:user_song, user: @user, song: create(:song))
+      create(:user_song, user: @user, song: create(:song))
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+
+      VCR.use_cassette 'recommended_get_recommendations' do
+        visit dashboard_path
+      end
+    end
+
+    it 'I see a form to create a playlist on Spotify using recommended songs' do
+      within '.recommended-songs' do
+        within '.playlist-export' do
+          expect(page).to have_field :playlist_name
+          expect(page).to have_button 'Create Spotify Playlist'
+        end
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -17,6 +17,8 @@ VCR.configure do |config|
   config.hook_into :webmock
   config.configure_rspec_metadata!
   config.filter_sensitive_data('<STRAVA_TEST_TOKEN>') { ENV['STRAVA_TEST_TOKEN'] }
+  config.filter_sensitive_data('<SPOTIFY_UID>') { ENV['SPOTIFY_UID'] }
+  config.filter_sensitive_data('<SPOTIFY_TEST_TOKEN>') { ENV['SPOTIFY_TEST_TOKEN'] }
 end
 # Add additional requires below this line. Rails is not loaded until this point!
 


### PR DESCRIPTION
This PR adds a form to the user dashboard allowing them to export their recommended songs to a playlist in Spotify.  Additionally:

- Adds spec for user seeing Spotify playlist export in the recommended songs section of the dashboard
- Adds a Playlist controller, which calls the SpotifyService to both create a playlist and populate that playlist with songs
- Adds an additional VCR cassette and VCR filters
- Refactors the DashboardFacade, and adds additional calls to the SpotifyService for posting a new playlist and populating that playlist