### PR TITLE
Recommended Song PORO

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,6 +15,7 @@
 //= require jquery3
 //= require jquery_ujs
 //= require_tree .
+//= require Chart.bundle.min
 
 $(document).ready(function(){
 	$("#refresh-recs").click(function(){
@@ -26,7 +27,7 @@ $(document).ready(function(){
      data : params,
      dataType: "json",
      success: function (new_recommended) {
-				var i 
+				var i
 				for (i = 0; i < 5; i++) {
 					$('.recommended-iframe')[i].src = 'https://open.spotify.com/embed/track/' + new_recommended[i].spotify_id
 				}

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -27,7 +27,7 @@ $(document).ready(function(){
      data : params,
      dataType: "json",
      success: function (new_recommended) {
-				var i
+				var i;
 				for (i = 0; i < 5; i++) {
 					$('.recommended-iframe')[i].src = 'https://open.spotify.com/embed/track/' + new_recommended[i].spotify_id
 				}

--- a/app/facades/dashboard_show_facade.rb
+++ b/app/facades/dashboard_show_facade.rb
@@ -10,19 +10,21 @@ class DashboardShowFacade
   end
 
   def spotify_song_uris
-    recommended_songs.map { |song| 'spotify:track:' + song[:spotify_id] }.join(',')
+    recommended_songs.map { |song| 'spotify:track:' + song.spotify_id }.join(',')
   end
 
   def recommended_songs
     songs = @user.top_songs(5).map(&:spotify_id).join(',')
-    @recommended_songs ||= recommended_service.get_recommendations(songs)
+    @recommended_songs ||= recommended_service.get_recommendations(songs).map do |song|
+      RecommendedSong.new(song)
+    end
   end
-	
+
 	def recommended_api_url
     song_ids = @user.top_songs(5).map{|song| song.spotify_id}.join(',')
 		limit = "limit=5&"
 		limit + "song_ids=" + song_ids
-	end	
+	end
 
   def build_link
     link = 'https://accounts.spotify.com/authorize?'

--- a/app/models/recommended_song.rb
+++ b/app/models/recommended_song.rb
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
+# Top Level Class Documentation
 class RecommendedSong
   attr_reader :spotify_id
 

--- a/app/models/recommended_song.rb
+++ b/app/models/recommended_song.rb
@@ -1,0 +1,7 @@
+class RecommendedSong
+  attr_reader :spotify_id
+
+  def initialize(data)
+    @spotify_id = data[:spotify_id]
+  end
+end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -67,7 +67,7 @@
                 <% cache cache_key_for(Song, "recommended-song") do %>
                   <% facade.recommended_songs.each do |song| %>
                     <div class="recommended-song">
-                      <iframe class="recommended-iframe" src="https://open.spotify.com/embed/track/<%= song[:spotify_id] %>" width="300" height="80" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe>
+                      <iframe class="recommended-iframe" src="https://open.spotify.com/embed/track/<%= song.spotify_id %>" width="300" height="80" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe>
                     </div>
                   <% end %>
                 <% end %>

--- a/spec/models/recommended_song_spec.rb
+++ b/spec/models/recommended_song_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require './app/models/recommended_song'
+
+RSpec.describe RecommendedSong, type: :model do
+  it 'has only a spotify_id' do
+    data = {
+      :album=>"FML",
+      :album_art_url=>"https://i.scdn.co/image/f4df5c3409bb23c7170639a0132849c600594e24",
+      :artist=>"K.Flay",
+      :length=>207724,
+      :spotify_id=>"6kbCH9kQoNzaEt1R1rizpR",
+      :spotify_url=>"https://open.spotify.com/track/6kbCH9kQoNzaEt1R1rizpR",
+      :title=>"FML"
+    }
+    song = RecommendedSong.new(data)
+
+    expect(song.spotify_id).to eq('6kbCH9kQoNzaEt1R1rizpR')
+    expect(song).to_not respond_to('.name')
+    expect(song).to_not respond_to('.artist')
+
+  end
+end

--- a/spec/models/recommended_song_spec.rb
+++ b/spec/models/recommended_song_spec.rb
@@ -6,19 +6,18 @@ require './app/models/recommended_song'
 RSpec.describe RecommendedSong, type: :model do
   it 'has only a spotify_id' do
     data = {
-      :album=>"FML",
-      :album_art_url=>"https://i.scdn.co/image/f4df5c3409bb23c7170639a0132849c600594e24",
-      :artist=>"K.Flay",
-      :length=>207724,
-      :spotify_id=>"6kbCH9kQoNzaEt1R1rizpR",
-      :spotify_url=>"https://open.spotify.com/track/6kbCH9kQoNzaEt1R1rizpR",
-      :title=>"FML"
+      album: 'FML',
+      album_art_url: 'https://i.scdn.co/image/f4df5c3409bb23c7170639a0132849c600594e24',
+      artist: 'K.Flay',
+      length: 207724,
+      spotify_id: '6kbCH9kQoNzaEt1R1rizpR',
+      spotify_url: 'https://open.spotify.com/track/6kbCH9kQoNzaEt1R1rizpR',
+      title: 'FML'
     }
     song = RecommendedSong.new(data)
 
     expect(song.spotify_id).to eq('6kbCH9kQoNzaEt1R1rizpR')
     expect(song).to_not respond_to('.name')
     expect(song).to_not respond_to('.artist')
-
   end
 end


### PR DESCRIPTION
This PR brings in a PORO for us to render RecommendedSongs correctly on the Dashboard view. Previously, we were just accessing the hash that we built, which is not Ruby Idiomatic.
This PORO is very simple, just taking in a Sifted Song and pulling the SpotifyID. That's it.

Also this brings back our requirement for rendering Charts in `application.js` of the `Chart.bundle.min` package.