### PR TITLE
Add ENV['SPOTIFY_REDIRECT_URL'] to the Config Variables

### DIFF
--- a/app/facades/dashboard_show_facade.rb
+++ b/app/facades/dashboard_show_facade.rb
@@ -28,7 +28,7 @@ class DashboardShowFacade
     link = 'https://accounts.spotify.com/authorize?'
     client_pair = "client_id=#{ENV['SPOTIFY_CLIENT_ID']}&"
     code_pair = 'response_type=code&'
-    redirect_pair = 'redirect_uri=https://rocky-springs-29283.herokuapp.com/auth/spotify/callback&'
+    redirect_pair = "redirect_uri=#{ENV['SPOTIFY_REDIRECT_URL']}/auth/spotify/callback&"
     scope_pair = 'scope=user-read-recently-played,playlist-modify-public'
     link + client_pair + code_pair + redirect_pair + scope_pair
   end

--- a/app/models/spotify_oauth_generator.rb
+++ b/app/models/spotify_oauth_generator.rb
@@ -4,7 +4,7 @@
 class SpotifyOauthGenerator
   def initialize(code)
     @code = code
-    @redirect_uri = 'https://rocky-springs-29283.herokuapp.com/auth/spotify/callback'
+    @redirect_uri = "#{ENV['SPOTIFY_REDIRECT_URL']}/auth/spotify/callback"
     @conn = Faraday.new('https://accounts.spotify.com/') do |faraday|
       faraday.adapter Faraday.default_adapter
     end


### PR DESCRIPTION
 To ensure stable transfer between development, staging, and production for our handrolled Spotify OAuth process.
This will resolve all of our issues. It has already been added as a config var in staging.