### PR TITLE
Fix simple caching for Dashboard Recommended songs

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -64,7 +64,7 @@
                     <%= submit_tag 'Create or Update Playlist', class: 'btn btn-success' %>
                   <% end %>
                 </section>
-                <% cache cache_key_for(Song, "recommended-song") do %>
+                <% cache("recommended-songs", expires_in: 30.minutes) do %>
                   <% facade.recommended_songs.each do |song| %>
                     <div class="recommended-song">
                       <iframe class="recommended-iframe" src="https://open.spotify.com/embed/track/<%= song[:spotify_id] %>" width="300" height="80" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe>


### PR DESCRIPTION
This caching change will now keep the Recommended Songs iframes cached for 30 minutes, allowing a user to keep track of their recommended songs for at least a little bit of time.