### PR TITLE
Layout fixes: Welcome Image, FastTracks Navbar

### DIFF
--- a/app/views/songs/show.html.erb
+++ b/app/views/songs/show.html.erb
@@ -27,13 +27,17 @@
         </div>
       </div>
     </div>
-
+    
     <div class="col-lg-4">
       <% if facade.activity_count >=3 %>
-        <section id='pr-chart'>
-          <h3>PowerRanking Over Time</h3>
-          <%= line_chart facade.chart_data, facade.chart_options %>
-        </section>
+        <div class="card">
+          <div class="card-header">
+            <h4 id='song-title' class="card-title">PowerRanking Over Time</h4>
+          </div>
+          <section id='pr-chart'>
+            <%= line_chart facade.chart_data, facade.chart_options %>
+          </section>
+        </div>
       <% end %>
     </div>
   </div>

--- a/app/views/songs/show.html.erb
+++ b/app/views/songs/show.html.erb
@@ -31,7 +31,7 @@
     <div class="col-lg-4">
       <% if facade.activity_count >=3 %>
         <div class="card">
-          <div class="card-header">
+          <div class="card-header pr-header">
             <h4 id='song-title' class="card-title">PowerRanking Over Time</h4>
           </div>
           <section id='pr-chart'>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,6 +2,7 @@
   <a href="<%= dashboard_path %>">
     <img src="<%= image_url('fasttracks-logo.png') %>">
   </a>
+  <h1 class="nav-title">FastTracks</h1>
 </nav>
 <section class="container main-content">
 

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -22,6 +22,6 @@
     padding-top: 170px;
     background-size: cover;
     background-repeat: no-repeat;
-    background-image: linear-gradient(rgba(0,0,0,.4), rgba(0,0,0,.5), rgba(0,0,0,.65)), url("/assets/welcome/bike_scene.jpg");
+    background-image: linear-gradient(rgba(0,0,0,.4), rgba(0,0,0,.5), rgba(0,0,0,.65)), url("https://images.unsplash.com/photo-1471506480208-91b3a4cc78be?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1953&q=80");
   }
 </style>

--- a/spec/features/users/user_can_visit_song_show_spec.rb
+++ b/spec/features/users/user_can_visit_song_show_spec.rb
@@ -29,8 +29,11 @@ describe 'As a fully connected user' do
 
       visit song_path(@song)
 
-      within('#pr-chart') do
+      within('.pr-header') do
         expect(page).to have_content('PowerRanking Over Time')
+      end
+
+      within('#pr-chart') do
         expect(page).to have_css('#chart-0')
       end
     end


### PR DESCRIPTION
Add fix to background image on welcome index page. 
Add 'FastTracks' brand to navbar on users show page. 
Add bootstrap card around graph on song show page. 

resolves US-75