### PR TITLE
Pending Chart User Song Show

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -6,6 +6,21 @@ canvas {
   max-width: 400px;
   height: auto !important;
 }
+#pending-chart img {
+  width: 100% !important;
+  max-width: 400px;
+  height: auto !important;
+}
+#pending-chart div {
+	opacity: 0.25
+}
+#pending-chart p {
+   position: absolute;
+   top: 200px;
+   left: 0;
+   width: 100%;
+	 text-align: center;
+}
 body {
 	font-family: 'Muli', sans-serif;
 }

--- a/app/views/songs/show.html.erb
+++ b/app/views/songs/show.html.erb
@@ -27,18 +27,25 @@
         </div>
       </div>
     </div>
-    
+
     <div class="col-lg-4">
-      <% if facade.activity_count >=3 %>
         <div class="card">
           <div class="card-header pr-header">
-            <h4 id='song-title' class="card-title">PowerRanking Over Time</h4>
+            <h4 id='power-ranking-over-time' class="card-title">PowerRanking Over Time</h4>
           </div>
-          <section id='pr-chart'>
-            <%= line_chart facade.chart_data, facade.chart_options %>
-          </section>
+          <% if facade.activity_count >=3 %>
+            <section id='pr-chart'>
+              <%= line_chart facade.chart_data, facade.chart_options %>
+            </section>
+          <% else %>
+            <section id='pending-chart'>
+              <div id="chart-opacity-layer">
+                <img src="https://i.imgur.com/mnMN1uY.png" alt="Pending PR Chart">
+              </div>
+              <p>Get a couple more rides in and you'll have some stats!</p>
+            </section>
+          <% end %>
         </div>
-      <% end %>
     </div>
   </div>
 </section>

--- a/spec/features/users/user_can_visit_song_show_spec.rb
+++ b/spec/features/users/user_can_visit_song_show_spec.rb
@@ -62,10 +62,15 @@ describe 'As a fully connected user' do
       end
     end
 
-    it 'does not display a graph if there are less than 3 activities attached' do
+    it 'does not display a real graph if there are less than 3 activities attached' do
       visit song_path(@song)
 
-      expect(page).to_not have_content('PowerRanking Over Time')
+      expect(page).to have_content('PowerRanking Over Time')
+      within '#pending-chart' do
+        expect(page).to have_content("Get a couple more rides in and you'll have some stats!")
+        expect(page).to have_selector("img[src='https://i.imgur.com/mnMN1uY.png']")
+        expect(page).to have_css("div[id='chart-opacity-layer']")
+      end
       expect(page).to_not have_css('#chart-0')
     end
   end


### PR DESCRIPTION
This PR brings in the functionality for a pending chart to be shown to a user when they visit a Song Show page and they have less than 3 activities recorded listening to that Song. Prior, they would just not see a chart at all.
The new implementation takes an image of a chart, with an opacity overlay, and text explaining that they need to get a couple more rides in.
Unable to test opacity currently because the `rack-test` driver doesn't process CSS. Should probably test this at some point later.